### PR TITLE
Optimize static asset caching with ETag and Last-Modified

### DIFF
--- a/back-js/routes.js
+++ b/back-js/routes.js
@@ -79,7 +79,7 @@ export async function handleRoutes(req, url) {
   // 处理公共资源文件
   if (url.pathname === "/common.css" || url.pathname === "/common.js" || url.pathname === "/common.less") {
     const filePath = `front${url.pathname}`; // 映射到front目录下
-    return await handleStaticCache(req, filePath, 'max-age=86400');
+    return await handleStaticCache(req, filePath);
   }
 
   // 处理其他静态文件
@@ -89,7 +89,7 @@ export async function handleRoutes(req, url) {
       url.pathname.startsWith("/images/") || 
       url.pathname.startsWith("/fonts/")) {
     const filePath = url.pathname.substring(1); // 移除开头的 "/"
-    return await handleStaticCache(req, filePath, 'max-age=86400');
+    return await handleStaticCache(req, filePath);
   }
   
   // API 路由
@@ -295,7 +295,7 @@ async function handleFaviconCache(req) {
   return await createCachedResponse(filePath, 'max-age=86400'); // favicon缓存1天
 }
 
-async function handleStaticCache(req, filePath, cacheControl = 'max-age=86400') {
+async function handleStaticCache(req, filePath, cacheControl) {
   const ifModifiedSince = req.headers.get("if-modified-since");
   const ifNoneMatch = req.headers.get("if-none-match");
   

--- a/back-js/utils.js
+++ b/back-js/utils.js
@@ -158,7 +158,7 @@ export async function shouldReturn304WithETag(filePath, ifNoneMatch) {
 }
 
 // 创建带缓存头的响应
-export async function createCachedResponse(filePath, cacheControl = 'max-age=3') {
+export async function createCachedResponse(filePath, cacheControl) {
   try {
     const file = Bun.file(filePath);
     const lastModified = file.lastModified;
@@ -166,9 +166,13 @@ export async function createCachedResponse(filePath, cacheControl = 'max-age=3')
     
     const headers = {
       'Content-Type': getContentType(filePath),
-      'Last-Modified': formatLastModified(lastModified),
-      'Cache-Control': cacheControl
+      'Last-Modified': formatLastModified(lastModified)
     };
+
+    // 仅当明确传入 cacheControl 时才设置该响应头，避免在静态资源上使用 max-age
+    if (cacheControl) {
+      headers['Cache-Control'] = cacheControl;
+    }
     
     // 添加ETag头
     if (etag) {


### PR DESCRIPTION
Remove `max-age` cache control for `front` and `assert` directory static resources to rely on `ETag` and `Last-Modified` for 304 responses.

---
<a href="https://cursor.com/background-agent?bcId=bc-481e0c28-800e-40f9-af8a-83c8faf6f73b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-481e0c28-800e-40f9-af8a-83c8faf6f73b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>